### PR TITLE
fix(commands-plugin): ensure currentCommand is updated correctly on c…

### DIFF
--- a/enapter-commands-panel/src/components/CommandSelect.tsx
+++ b/enapter-commands-panel/src/components/CommandSelect.tsx
@@ -61,7 +61,7 @@ export const CommandSelect: React.FC = () => {
       updatePanel((draft) => {
         draft.currentCommand = cloneDeep(current(draft.commands[v.value!]));
       });
-    });0
+    });
   };
 
   return (

--- a/enapter-commands-panel/src/components/CommandSelect.tsx
+++ b/enapter-commands-panel/src/components/CommandSelect.tsx
@@ -3,6 +3,8 @@ import { Field, Select, useStyles2 } from '@grafana/ui';
 import { usePanel } from './PanelProvider';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css } from '@emotion/css';
+import { cloneDeep } from 'lodash';
+import { current } from 'immer';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
@@ -52,8 +54,14 @@ export const CommandSelect: React.FC = () => {
 
   const handleOnChange = async (v: SelectableValue<string>) => {
     updatePanel((draft) => {
-      draft.currentCommand = draft.commands[v.value!];
+      draft.currentCommand = undefined;
     });
+
+    requestAnimationFrame(() => {
+      updatePanel((draft) => {
+        draft.currentCommand = cloneDeep(current(draft.commands[v.value!]));
+      });
+    });0
   };
 
   return (


### PR DESCRIPTION
Applied a hacky workaround because Grafana does us a disservice with its automatic deep merging of old and new panel state.

This "helpful" feature has no opt-out and causes stale argument values to persist when switching between commands. 

The workaround sets currentCommand to undefined first, then applies the actual value in the next frame via requestAnimationFrame, forcing Grafana to treat it as a fresh object rather than merging it with the previous state. 

A clean solution would require rewriting the plugin's state management. 

Fixes #48 

Disclaimer: everything written above might be complete nonsense due to my limited understanding of Grafana internals. If you know a better way, please don't judge me too harshly.