### PR TITLE
fix(datasource): support non-string fields in JSON data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Release
 enapter-grafana-plugins.tar.gz
+
+# Env
+.env

--- a/enapter-api-datasource/pkg/grafana/data_source_instance.go
+++ b/enapter-api-datasource/pkg/grafana/data_source_instance.go
@@ -26,7 +26,7 @@ type dataSourceInstance struct {
 	backend.CheckHealthHandler
 }
 
-func newDataSourceInstance(
+func NewDataSourceInstance(
 	logger hclog.Logger, settings backend.DataSourceInstanceSettings,
 ) (_ *dataSourceInstance, retErr error) {
 	logger = logger.Named(fmt.Sprintf("data_source[%q]", settings.Name))
@@ -38,13 +38,17 @@ func newDataSourceInstance(
 		}
 	}()
 
-	var jsonData map[string]string
+	var jsonData struct {
+		EnapterAPIURL     string `json:"enapterAPIURL"`
+		EnapterAPIVersion string `json:"enapterAPIVersion"`
+		UserResolverURL   string `json:"userResolverURL"`
+	}
 	if err := json.Unmarshal(settings.JSONData, &jsonData); err != nil {
 		return nil, fmt.Errorf("JSON data: %w", err)
 	}
 
-	apiURL := jsonData["enapterAPIURL"]
-	apiVersion := jsonData["enapterAPIVersion"]
+	apiURL := jsonData.EnapterAPIURL
+	apiVersion := jsonData.EnapterAPIVersion
 	apiToken := settings.DecryptedSecureJSONData["enapterAPIToken"]
 
 	var enapterAPIAdapter enapterAPIAdapter
@@ -76,7 +80,7 @@ func newDataSourceInstance(
 	}
 
 	var userResolver core.UserResolverPort = core.NoopUserResolver{}
-	if url := jsonData["userResolverURL"]; url != "" {
+	if url := jsonData.UserResolverURL; url != "" {
 		userResolver = http.NewUserResolverAdapter(http.UserResolverAdapterParams{
 			URL: url,
 		})

--- a/enapter-api-datasource/pkg/grafana/data_source_instance_test.go
+++ b/enapter-api-datasource/pkg/grafana/data_source_instance_test.go
@@ -1,0 +1,33 @@
+package grafana_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Enapter/grafana-plugins/pkg/grafana"
+)
+
+func TestNewDataSourceInstance(t *testing.T) {
+	logger := hclog.NewNullLogger()
+
+	t.Run("should NOT fail if JSONData contains boolean", func(t *testing.T) {
+		jsonData, err := json.Marshal(map[string]any{
+			"enapterAPIURL":     "https://api.enapter.com",
+			"enapterAPIVersion": "v3",
+			"tlsSkipVerify":     true,
+		})
+		require.NoError(t, err)
+
+		settings := backend.DataSourceInstanceSettings{
+			JSONData: jsonData,
+		}
+
+		instance, err := grafana.NewDataSourceInstance(logger, settings)
+		require.NoError(t, err)
+		require.NotNil(t, instance)
+	})
+}

--- a/enapter-api-datasource/pkg/grafana/plugin.go
+++ b/enapter-api-datasource/pkg/grafana/plugin.go
@@ -33,5 +33,5 @@ func (p *Plugin) Serve() error {
 func (p *Plugin) newDataSource(
 	settings backend.DataSourceInstanceSettings,
 ) (instancemgmt.Instance, error) {
-	return newDataSourceInstance(p.logger, settings)
+	return NewDataSourceInstance(p.logger, settings)
 }


### PR DESCRIPTION
Refactor 'dataSourceInstance' initialization to use a structured struct for JSON unmarshaling instead of a map[string]string. This prevents errors when the JSON data contains non-string types (e.g., booleans like 'tlsSkipVerify' added by Grafana's default UI), which previously caused unmarshaling to fail.